### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=4.0.0",
-        "pear/PEAR": ">=1.5.4",
-        "pear/pear_exception": "*"
+        "php": ">=4.0.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Without this change, trying to install package leads to error:

```
  Problem 1
    - Installation request for pear/cache_lite dev-master -> satisfiable by pear/cache_lite[dev-master].
    - pear/cache_lite dev-master requires pear/pear >=1.5.4 -> no matching package found.
```
