### PR TITLE
PHP7 has deprecated same-named functions as constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: php
+
+before_install:
+  - pear upgrade pear
+
 install:
   - pear install package.xml
+
 php:
   - 5.4
-  - 5.3
+  - 5.5
+  - 5.6
+  - 7.0
+
 script: phpunit tests/

--- a/Cache/Lite.php
+++ b/Cache/Lite.php
@@ -294,7 +294,7 @@ class Cache_Lite
     * @param array $options options
     * @access public
     */
-    function Cache_Lite($options = array(NULL))
+    function __construct($options = array(NULL))
     {
         foreach($options as $key => $value) {
             $this->setOption($key, $value);

--- a/Cache/Lite/File.php
+++ b/Cache/Lite/File.php
@@ -52,10 +52,10 @@ class Cache_Lite_File extends Cache_Lite
     * @param array $options options
     * @access public
     */
-    function Cache_Lite_File($options = array(NULL))
+    function __construct($options = array(NULL))
     {   
         $options['lifetime'] = 0;
-        $this->Cache_Lite($options);
+        parent::__construct($options);
         if (isset($options['masterFile'])) {
             $this->_masterFile = $options['masterFile'];
         } else {

--- a/Cache/Lite/Function.php
+++ b/Cache/Lite/Function.php
@@ -81,7 +81,7 @@ class Cache_Lite_Function extends Cache_Lite
     * @param array $options options
     * @access public
     */
-    function Cache_Lite_Function($options = array(NULL))
+    function __construct($options = array(NULL))
     {
         $availableOptions = array('debugCacheLiteFunction', 'defaultGroup', 'dontCacheWhenTheOutputContainsNOCACHE', 'dontCacheWhenTheResultIsFalse', 'dontCacheWhenTheResultIsNull');
         while (list($name, $value) = each($options)) {
@@ -91,7 +91,7 @@ class Cache_Lite_Function extends Cache_Lite
             }
         }
         reset($options);
-        $this->Cache_Lite($options);
+        parent::__construct($options);
     }
 
     /**

--- a/Cache/Lite/Output.php
+++ b/Cache/Lite/Output.php
@@ -26,9 +26,9 @@ class Cache_Lite_Output extends Cache_Lite
     * @param array $options options
     * @access public
     */
-    function Cache_Lite_Output($options)
+    function __construct($options)
     {
-        $this->Cache_Lite($options);
+        parent::__construct($options);
     }
 
     /**

--- a/package.xml
+++ b/package.xml
@@ -87,7 +87,7 @@
     <dependencies>
         <required>
             <php>
-                <min>4.0.0</min>
+                <min>5.4.0</min>
             </php>
             <pearinstaller>
                 <min>1.5.4</min>

--- a/package.xml
+++ b/package.xml
@@ -95,6 +95,7 @@
             <package>
                 <name>PEAR</name>
                 <channel>pear.php.net</channel>
+                <min>1.10.1</min>
             </package>
         </required>
     </dependencies>

--- a/tests/Cache_Lite_Function_classical.phpt
+++ b/tests/Cache_Lite_Function_classical.phpt
@@ -55,7 +55,7 @@ class bench
         return "\$obj->test = $this->test and this is the result of the method \$obj->method_to_bench($arg1, $arg2) !\n";        
     }
     
-    function static_method_to_bench($arg1, $arg2) {
+    static function static_method_to_bench($arg1, $arg2) {
         echo "This is the output of the function static_method_to_bench($arg1, $arg2) !\n";
         return "This is the result of the function static_method_to_bench($arg1, $arg2) !\n";
     }

--- a/tests/Cache_Lite_Function_classical.phpt
+++ b/tests/Cache_Lite_Function_classical.phpt
@@ -64,7 +64,7 @@ class bench
 
 class test
 {
-    function test($options) {
+    function __construct($options) {
         $this->foo = 'bar';
         $cache = new Cache_Lite_Function($options);
         echo($cache->call(array($this, 'method_to_bench'), 'foo', 'bar'));


### PR DESCRIPTION
As per, http://php.net/manual/en/language.oop5.decon.php, "Old style
constructors are DEPRECATED in PHP 7.0, and will be removed in a future
version. You should always use __construct() in new code." The current
tests fail on PHP7.0 based installs due to the deprecation warnings.

Signed-off-by: Nishanth Aravamudan <nish.aravamudan@canonical.com>