### PR TITLE
Composer and PEAR manifests don't match

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=4.0.0"
+        "php": ">=5.4.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
The declared minimum supported PHP version doesn't match in the Composer and PEAR manifests.  Corrected Composer to match PEAR.
