### PR TITLE
Fix for PHP 7.2

### DIFF
--- a/Cache/Lite/Function.php
+++ b/Cache/Lite/Function.php
@@ -84,7 +84,7 @@ class Cache_Lite_Function extends Cache_Lite
     function __construct($options = array(NULL))
     {
         $availableOptions = array('debugCacheLiteFunction', 'defaultGroup', 'dontCacheWhenTheOutputContainsNOCACHE', 'dontCacheWhenTheResultIsFalse', 'dontCacheWhenTheResultIsNull');
-        while (list($name, $value) = each($options)) {
+        foreach ($options as $name => $value) {
             if (in_array($name, $availableOptions)) {
                 $property = '_'.$name;
                 $this->$property = $value;

--- a/package.xml
+++ b/package.xml
@@ -79,6 +79,7 @@
             <file baseinstalldir="/" name="/tests/pearbug18192.php" role="test"/>
             <file baseinstalldir="/" name="/tests/pearbug18328.phpt" role="test"/>
             <file baseinstalldir="/" name="/tests/pearbug19422.phpt" role="test"/>
+            <file baseinstalldir="/" name="/tests/pearbug19711.phpt" role="test"/>
             <file baseinstalldir="/" name="/tests/readme" role="test"/>
             <file baseinstalldir="/" name="/tests/tmpdir.inc" role="test"/>
             <file baseinstalldir="/" name="/tests/ErrorDieTest.php" role="test"/>

--- a/tests/pearbug19422.phpt
+++ b/tests/pearbug19422.phpt
@@ -116,6 +116,14 @@ var_dump(strlen($data) === strlen($verify));
 var_dump($data === $verify);
 
 ?>
+--CLEAN--
+<?php
+define('FsStreamWrapper_CACHE_DIR', sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'cachelite-streamwrapper' . DIRECTORY_SEPARATOR);
+foreach(glob(FsStreamWrapper_CACHE_DIR . 'cache*') as $file) {
+  unlink($file);
+}
+@rmdir(FsStreamWrapper_CACHE_DIR);
+?>
 --GET--
 --POST--
 --EXPECT--


### PR DESCRIPTION
3rd commit if for 7.2, other are only cleanup

```
$ php -v
PHP 7.2.2 (cli) (built: Jan 30 2018 10:33:36) ( NTS )

$ pear run-tests tests
Running 21 tests
PASS [ 1/21] Cache_Lite::Cache_Lite_File (classical)[tests/Cache_Lite_File_classical.phpt]
PASS [ 2/21] Cache_Lite::Cache_Lite_Function (classical)[tests/Cache_Lite_Function_classical.phpt]
PASS [ 3/21] Cache_Lite::Cache_Lite_Function (dont cache)[tests/Cache_Lite_Function_dontcache.phpt]
PASS [ 4/21] Cache_Lite::Cache_Lite_Function (drop() method)[tests/Cache_Lite_Function_drop.phpt]
PASS [ 5/21] Cache_Lite::Cache_Lite_Output (classical)[tests/Cache_Lite_Output_classical.phpt]
PASS [ 6/21] Cache_Lite::Cache_Lite (automaticCleaning)[tests/Cache_Lite_automaticCleaning.phpt]
PASS [ 7/21] Cache_Lite::Cache_Lite (classical)[tests/Cache_Lite_classical.phpt]
PASS [ 8/21] Cache_Lite::Cache_Lite (error)[tests/Cache_Lite_error.phpt]
PASS [ 9/21] Cache_Lite::Cache_Lite (error2)[tests/Cache_Lite_error2.phpt]
PASS [10/21] Cache_Lite::Cache_Lite (eternal)[tests/Cache_Lite_eternal.phpt]
PASS [11/21] Cache_Lite::Cache_Lite (fatest, no control, no lock)[tests/Cache_Lite_fatest.phpt]
PASS [12/21] Cache_Lite::Cache_Lite (hashed level 2)[tests/Cache_Lite_hashed.phpt]
PASS [13/21] Cache_Lite::Cache_Lite (lifetime)[tests/Cache_Lite_lifetime.phpt]
PASS [14/21] Cache_Lite::Cache_Lite (memory cache on)[tests/Cache_Lite_memorycache.phpt]
PASS [15/21] Cache_Lite::Cache_Lite (automatic serialization on)[tests/Cache_Lite_serialization.phpt]
PASS [16/21] pearbug513[tests/pearbug513.phpt]
PASS [17/21] pearbug7618[tests/pearbug7618.phpt]
PASS [18/21] pearbug13693[tests/pearbug13693.phpt]
PASS [19/21] Cache_Lite::Cache_Lite (PEAR bug #18328)[tests/pearbug18328.phpt]
PASS [20/21] Cache_Lite::Cache_Lite (PEAR bug #19422)[tests/pearbug19422.phpt]
PASS [21/21] Cache_Lite::Cache_Lite (PEAR bug #19711)[tests/pearbug19711.phpt]
TOTAL TIME: 00:22
21 PASSED TESTS
0 SKIPPED TESTS

```