### PR TITLE
Fix failing CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ php:
 
 script:
   - composer install
-  - phpunit tests/
+  - vendor/bin/phpunit tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ php:
   - 5.6
   - 7.0
 
-script: phpunit tests/
+script:
+  - composer install
+  - phpunit tests/

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "source": "https://github.com/pear/Cache_Lite"
     },
     "require-dev": {
-        "phpunit/phpunit": "*"
+        "phpunit/phpunit": "~5.3.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "source": "https://github.com/pear/Cache_Lite"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.3.0"
+        "phpunit/phpunit": "^4"
     }
 }


### PR DESCRIPTION
Downgraded PHPUnit version from `*` into 4 because 

1. To run PHPUnit on PHP 5.4, it requires PHPUnit version 4.
    * refs: [Dropping support for PHP 5\.3, PHP 5\.4, and PHP 5\.5](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.0.0#dropping-support-for-php-53-php-54-and-php-55)
1. PHPUnit 5 does not support PHPT file.
    * refs: https://travis-ci.org/pear/Cache_Lite/jobs/340946401

By using PHPUnit 4, it was fixed that CI was failing. 😄 