### PR TITLE
Add PHP 7.1 and 7.2 to run PHPUnit on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 script:
   - composer install

--- a/Cache/Lite.php
+++ b/Cache/Lite.php
@@ -708,8 +708,9 @@ class Cache_Lite
         $this->_touchCacheFile();
         $this->_memoryCachingArray[$this->_file] = $data;
         if ($this->_memoryCachingCounter >= $this->_memoryCachingLimit) {
-            list($key, ) = each($this->_memoryCachingArray);
-            unset($this->_memoryCachingArray[$key]);
+            foreach ($this->_memoryCachingArray as $key => $value) {
+                unset($this->_memoryCachingArray[$key]);
+            }
         } else {
             $this->_memoryCachingCounter = $this->_memoryCachingCounter + 1;
         }

--- a/tests/Cache_Lite_File_classical.phpt
+++ b/tests/Cache_Lite_File_classical.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite_File (classical)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_Function_classical.phpt
+++ b/tests/Cache_Lite_Function_classical.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite_Function (classical)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_Function_dontcache.phpt
+++ b/tests/Cache_Lite_Function_dontcache.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite_Function (dont cache)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_Function_drop.phpt
+++ b/tests/Cache_Lite_Function_drop.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite_Function (drop() method)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_Output_classical.phpt
+++ b/tests/Cache_Lite_Output_classical.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite_Output (classical)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_automaticCleaning.phpt
+++ b/tests/Cache_Lite_automaticCleaning.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (automaticCleaning)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_classical.phpt
+++ b/tests/Cache_Lite_classical.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (classical)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_error.phpt
+++ b/tests/Cache_Lite_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (error)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_error2.phpt
+++ b/tests/Cache_Lite_error2.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (error2)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_eternal.phpt
+++ b/tests/Cache_Lite_eternal.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (eternal)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_fatest.phpt
+++ b/tests/Cache_Lite_fatest.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (fatest, no control, no lock)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_hashed.phpt
+++ b/tests/Cache_Lite_hashed.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (hashed level 2)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_lifetime.phpt
+++ b/tests/Cache_Lite_lifetime.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (lifetime)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_memorycache.phpt
+++ b/tests/Cache_Lite_memorycache.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (memory cache on)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/Cache_Lite_serialization.phpt
+++ b/tests/Cache_Lite_serialization.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (automatic serialization on)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/pearbug13693.phpt
+++ b/tests/pearbug13693.phpt
@@ -1,5 +1,7 @@
 --TEST--
 pearbug13693
+--INI--
+track_errors=Off
 --FILE--
 <?php
 require_once __DIR__ . '/bootstrap.php';

--- a/tests/pearbug18328.phpt
+++ b/tests/pearbug18328.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (PEAR bug #18328)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/pearbug19422.phpt
+++ b/tests/pearbug19422.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (PEAR bug #19422)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/pearbug19711.phpt
+++ b/tests/pearbug19711.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Cache_Lite::Cache_Lite (PEAR bug #19711)
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/pearbug513.phpt
+++ b/tests/pearbug513.phpt
@@ -1,5 +1,7 @@
 --TEST--
 pearbug513
+--INI--
+track_errors=Off
 --FILE--
 <?php
 

--- a/tests/pearbug7618.phpt
+++ b/tests/pearbug7618.phpt
@@ -1,5 +1,7 @@
 --TEST--
 pearbug7618
+--INI--
+track_errors=Off
 --FILE--
 <?php
 


### PR DESCRIPTION
I fixed as belows to add PHP 7.1 and 7.2 to run PHPUnit on Travis.

1. Removed each function which is deprecated in PHP 7.2.
1. Set `track_errors=Off` to disable track_errors in phpt test cases which is also deprecated in PHP 7.2.