### PR TITLE
fix(Lite): make _memoryCacheAdd not clear whole cache if limit reached

### DIFF
--- a/Cache/Lite.php
+++ b/Cache/Lite.php
@@ -708,9 +708,10 @@ class Cache_Lite
         $this->_touchCacheFile();
         $this->_memoryCachingArray[$this->_file] = $data;
         if ($this->_memoryCachingCounter >= $this->_memoryCachingLimit) {
-            foreach ($this->_memoryCachingArray as $key => $value) {
-                unset($this->_memoryCachingArray[$key]);
-            }
+            $key = key($this->_memoryCachingArray);
+            next($this->_memoryCachingArray);
+            unset($this->_memoryCachingArray[$key]);
+            
         } else {
             $this->_memoryCachingCounter = $this->_memoryCachingCounter + 1;
         }


### PR DESCRIPTION
As pointed out in https://github.com/pear/Cache_Lite/commit/0cbdfe7c39899aec86053e50a4f9e5616ee6b88f#r28003058 the change in #9 changes the behaviour of the function. It would clean out the complete cache, if the _memoryCachingLimit is reached, not just the oldest element.

The fix below replaces the [original `each` call](https://github.com/pear/Cache_Lite/blob/4d744978e6fe6ccd9675f9b1e8a97e3864ac0653/Cache/Lite.php#L711) with a key+next operation.