### PR TITLE
Prevent PHP warning: "opendir(/tmp/cache/): failed to open dir: No su…

### DIFF
--- a/Cache/Lite.php
+++ b/Cache/Lite.php
@@ -639,7 +639,7 @@ class Cache_Lite
                 return true;
             }
         }
-        if (!($dh = opendir($dir))) {
+        if (!($dh = @opendir($dir))) {
             return $this->raiseError('Cache_Lite : Unable to open cache directory !', -4);
         }
         $result = true;


### PR DESCRIPTION
…ch file or directory" when cache directory does not exist.