### PR TITLE
Add pear-core-minimal dependency, rather than relying on system PEAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ To test this package, run
 
     phpunit tests/
 
+To test with Composer dependencies rather than a global PEAR install, run
+
+    composer update
+    phpunit tests/
+
 To build, simply execute
 
     pear package

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=4.0.0"
+        "php": ">=4.0.0",
+        "pear/pear-core-minimal": "^1.10"
     },
     "autoload": {
         "classmap": [

--- a/tests/ErrorDieTest.php
+++ b/tests/ErrorDieTest.php
@@ -24,7 +24,7 @@ class ErrorDieTest extends PHPUnit_Framework_TestCase
             '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789Cache_Lite : Unable to write cache file : <cachedir>/31451992gjhgjh/cache_c21f969b5f03d33d43e04f8f136e7682_e9982ec5ca981bd365603623cf4b2277',
         ));
 
-        $this->assertEquals($message, $expected);
+        $this->assertEquals($expected, $message);
 
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,10 @@
 <?php
 
+// If a Composer autoload file exists, load it before running tests
+if ( file_exists(__DIR__ . '/../vendor/autoload.php') ) {
+	require_once __DIR__ . '/../vendor/autoload.php';
+}
+
 if (version_compare(PHP_VERSION, '5.4', '>=')) {
     error_reporting(E_ALL ^ E_STRICT);
 } else if (version_compare(PHP_VERSION, '5.3', '>=')) {

--- a/tests/errordie.php
+++ b/tests/errordie.php
@@ -9,6 +9,7 @@
  * @author Markus Tacker <tacker@php.net>
  */
 
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/callcache.inc';
 require_once __DIR__ . '/tmpdir.inc';
 require_once __DIR__ . '/cache_lite_base.inc';


### PR DESCRIPTION
When installing through Composer with no PEAR installation on the system, the error-handling requires a local copy of 'PEAR.php'.

The other changes allow the unit tests to be run on such a system: Composer updates the include_path when initialising the autoloader, so that the include('PEAR.php') works as expected.